### PR TITLE
Create a pointer to Serial class(es) through ctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,12 @@ I also need to create an interface to communicate with a phone or app on the des
 
 Initialize the Pentair class and give the RX and TX pin numbers of your RS485 module (I have the RS-485 Shield from linksprite).
 
-	// Create our pentair instance
+	// Create our pentair instance with SoftwareSerial
 	Pentair pentair(6, 7);		// RX, TX pins for RS-485 (shield)
+	
+	// Create our pentair instance with a HardwareSerial
+	Serial1 _serial1;
+	Pentair pentair(&_serial1);		// pass the address of the hardware serial
 
 Call *ProcessIncommingSerialMessages()*  in the *loop()* function to retrieve the bytes from the RS485 interface, 
 the library will then parse it and call the defined callback function (through '*SetCallback(PumpChanged)*' for example)

--- a/libraries/Pentair/Pentair.cpp
+++ b/libraries/Pentair/Pentair.cpp
@@ -10,8 +10,9 @@ Created by Filip Slaets, January 23, 2017.
 #endif
 
 #include "Pentair.h"
+#include "Stream.h"
 #include "SoftwareSerial.h"
-#include "../LinkedList/LinkedList.h"
+#include "LinkedList.h"
 
 
 
@@ -210,10 +211,24 @@ Pentair::Pentair(int rxPin, int txPin) {
 	bufferToProcess = LinkedList<byte>();
 	chatter = LinkedList<byte>();
 
-	preambleStd[0] = 255;	preambleStd[1] = 165;	preambleChlorinator[0] = 16;
+	preambleStd[0] = 255;	
+	preambleStd[1] = 165;	
+	preambleChlorinator[0] = 16;
 	preambleChlorinator[1] = 2;
 }
 
+Pentair::Pentair(Stream& serial))
+	_serial(serial)  // Need to initialise references before body
+{
+	_serial->begin(9600);
+	bufferToProcess = LinkedList<byte>();
+	chatter = LinkedList<byte>();
+
+	preambleStd[0] = 255;
+	preambleStd[1] = 165;
+	preambleChlorinator[0] = 16;
+	preambleChlorinator[1] = 2;
+}
 
 //*******************************************************************************//
 // Reading the RS485 Bus

--- a/libraries/Pentair/Pentair.h
+++ b/libraries/Pentair/Pentair.h
@@ -5,7 +5,7 @@ Created by Filip Slaets, January 23, 2017.
 #ifndef Pentair_h
 #define Pentair_h
 
-#include "SoftwareSerial.h"
+#include "Stream.h"
 #include "LinkedList.h"
 
 /*
@@ -99,7 +99,7 @@ public:
 // Class that will handle Pentair shizzle
 class Pentair {
 private:
-	SoftwareSerial* _serial;
+	Stream& _serial;
 	PumpHolder _pump;
 
 	// Reading variables (RS485)
@@ -117,8 +117,9 @@ private:
 public:
 	bool debugLog = false;
 public:
-	// Constructor
+	// Constructors
 	Pentair(int rxPin, int txPin);
+	Pentair(Stream& serial);
 
 	// Read the RS bus for new messages and decode them.
 	void ProcessIncommingSerialMessages();

--- a/pentair_hardware_serial/pentair_hardware_serial.ino
+++ b/pentair_hardware_serial/pentair_hardware_serial.ino
@@ -1,0 +1,69 @@
+#include "Pentair.h"
+
+// Create our pentair instance
+Serial1 _serial1;
+Pentair pentair(&_serial1);		// Hardware serial for communication
+
+void setup() {
+	// Initialize some debug output
+	Serial.begin(115200);
+	
+	// set a callback method for when a pump status changes
+	pentair.SetCallback(PumpChanged);
+	// indicate to do some debug logging on the serial bus
+	pentair.debugLog = true;
+
+	// Tell the pump to startup
+	pentair.PumpCommandSetPower(1, true);
+	
+	// Just tell a locally attached LED at pin A3 to light up
+	analogWrite(3, 255);
+}
+
+void loop() {
+	// Light up a LED on pin A5
+	analogWrite(5, 255);
+	
+	// Inspect the bus for incomming messages and process them
+	pentair.ProcessIncommingSerialMessages();
+
+	// Dim the led at pin A5
+	analogWrite(5, 0);
+	
+	// Wait a little bit
+	delay(500);
+}
+
+// Gets called when there is a change in attributes on the given pump
+void PumpChanged(Pump myPump) {
+	// Light up a LED on pin A2
+	analogWrite(2, 255);
+	
+	Serial.print("Pump "); Serial.print(myPump.pump); Serial.println(" has been changed.");
+	
+	delay(500);
+	
+	// Dim LED at pin A2
+	analogWrite(2, 0);
+}
+
+// Full Cyclic cycle
+// C: A500 d=60 s=10 c=04 l=01 FF       <0219> SETCTRL remote
+// P: A500 d=10 s=60 c=04 l=01 FF       <0219> CTRL is remote
+// C: A500 d=60 s=10 c=01 l=04 02E40012 <0212> WRITE (18) to 0x02e4
+// P: A500 d=10 s=60 c=01 l=02 0012 <012A>     VALIS (18)
+// C: A500 d=60 s=10 c=05 l=01 06       <0121> SETMOD 06 (Feature 1)
+// P: A500 d=10 s=60 c=05 l=01 06       <0121> MOD is 06
+// C: A500 d=60 s=10 c=06 l=01 0A       <0126> SETRUN 0a Started
+// P: A500 d=10 s=60 c=06 l=01 0A       <0126> RUN is 0a Started
+// C: A500 d=60 s=10 c=07 l=00          <011C> SEND status
+// P: A500 d=10 s=60 c=07 l=0f 0A0602024908B1120000000A000F22 <028E>
+
+// If the controller releases the pump the cyclic sequence changes to:
+
+// C: A500 d=60 s=10 c=04 l=01 00 <011A> SETCTRL local
+// P: A500 d=10 s=60 c=04 l=01 00 <011A> CTRL is local
+
+void DoCycleTest(){
+	pentair.PumpStatusCheck(1); // set to remote, ask status of pump 1, set back to local
+}


### PR DESCRIPTION
This gives the ability to switch from Serial implementation.
Added extra constructor for passing through a serial class, the existing one remains and initializes the softwareserial class for the given pins.